### PR TITLE
skip apk signing if file does not exist

### DIFF
--- a/twidere/build.gradle
+++ b/twidere/build.gradle
@@ -51,10 +51,16 @@ android {
     }
     buildTypes {
         debug {
-            signingConfig signingConfigs.debug
+            File signingPropFile = project.rootProject.file('signing.properties')
+            if (signingPropFile.exists()) {
+                signingConfig signingConfigs.debug
+            }
         }
         release {
-            signingConfig signingConfigs.release
+            File signingPropFile = project.rootProject.file('signing.properties')
+            if (signingPropFile.exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     lintOptions {


### PR DESCRIPTION
The original `build.gradle` results in a build error if the signing file isn't present.
This patch will make it possible to compile the project without signing key.

Now simply running `./gradlew build` in project root directory should work even if a signing key isn't present.
