### PR TITLE
Fix build errors

### DIFF
--- a/twidere/src/main/java/org/mariotaku/twidere/util/WindowAccessor.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/WindowAccessor.java
@@ -13,7 +13,7 @@ public class WindowAccessor {
         WindowAccessorL.setStatusBarColor(window, color);
     }
 
-    @TargetApi(Build.VERSION_CODES.L)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static class WindowAccessorL {
         public static void setStatusBarColor(Window window, int color) {
             window.setStatusBarColor(color);


### PR DESCRIPTION
Two build errors are fixed:

* A typo in  `twidere/src/main/java/org/mariotaku/twidere/util/WindowAccessor.java` causes a "symbol not found" error
* `git submodule update` failed because of a broken commit id