### PR TITLE
Fixed twitter status link handler, tested with Chrome.

### DIFF
--- a/twidere/src/main/AndroidManifest.xml
+++ b/twidere/src/main/AndroidManifest.xml
@@ -541,22 +541,28 @@
             <intent-filter>
                 <data
                     android:host="twitter.com"
-                    android:scheme="http"/>
+                    android:scheme="http"
+                    android:pathPrefix="/"/>
                 <data
                     android:host="twitter.com"
-                    android:scheme="https"/>
+                    android:scheme="https"
+                    android:pathPrefix="/"/>
                 <data
                     android:host="www.twitter.com"
-                    android:scheme="http"/>
+                    android:scheme="http"
+                    android:pathPrefix="/"/>
                 <data
                     android:host="www.twitter.com"
-                    android:scheme="https"/>
+                    android:scheme="https"
+                    android:pathPrefix="/"/>
                 <data
                     android:host="mobile.twitter.com"
-                    android:scheme="http"/>
+                    android:scheme="http"
+                    android:pathPrefix="/"/>
                 <data
                     android:host="mobile.twitter.com"
-                    android:scheme="https"/>
+                    android:scheme="https"
+                    android:pathPrefix="/"/>
 
                 <action android:name="android.intent.action.VIEW"/>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED"/>

--- a/twidere/src/main/java/org/mariotaku/twidere/activity/TwitterLinkHandlerActivity.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/activity/TwitterLinkHandlerActivity.java
@@ -133,6 +133,12 @@ public class TwitterLinkHandlerActivity extends Activity implements Constants {
                 final Uri.Builder builder = new Uri.Builder();
                 builder.scheme(SCHEME_TWIDERE);
                 builder.authority(AUTHORITY_STATUS);
+                // TODO: Must have an account_id but getDefaultAccountId() seems to return -1 always.
+                long default_account_id = getDefaultAccountId(this);
+                if (default_account_id == -1) {
+                    default_account_id = Utils.getAccountIds(this)[0];
+                }
+                builder.appendQueryParameter(QUERY_PARAM_ACCOUNT_ID, String.valueOf(default_account_id));
                 builder.appendQueryParameter(QUERY_PARAM_STATUS_ID, pathSegments.get(2));
                 return new Intent(Intent.ACTION_VIEW, builder.build());
             }

--- a/twidere/src/main/java/org/mariotaku/twidere/activity/TwitterLinkHandlerActivity.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/activity/TwitterLinkHandlerActivity.java
@@ -133,12 +133,6 @@ public class TwitterLinkHandlerActivity extends Activity implements Constants {
                 final Uri.Builder builder = new Uri.Builder();
                 builder.scheme(SCHEME_TWIDERE);
                 builder.authority(AUTHORITY_STATUS);
-                // TODO: Must have an account_id but getDefaultAccountId() seems to return -1 always.
-                long default_account_id = getDefaultAccountId(this);
-                if (default_account_id == -1) {
-                    default_account_id = Utils.getAccountIds(this)[0];
-                }
-                builder.appendQueryParameter(QUERY_PARAM_ACCOUNT_ID, String.valueOf(default_account_id));
                 builder.appendQueryParameter(QUERY_PARAM_STATUS_ID, pathSegments.get(2));
                 return new Intent(Intent.ACTION_VIEW, builder.build());
             }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/Utils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/Utils.java
@@ -1700,7 +1700,9 @@ public final class Utils implements Constants, TwitterConstants {
     public static long getDefaultAccountId(final Context context) {
         if (context == null) return -1;
         final SharedPreferences prefs = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        return prefs.getLong(KEY_DEFAULT_ACCOUNT_ID, -1);
+        long account_id = prefs.getLong(KEY_DEFAULT_ACCOUNT_ID, -1);
+        if (account_id == -1) account_id = Utils.getAccountIds(context)[0]; /* TODO: this is just a quick fix */
+        return account_id;
     }
 
     public static String getDefaultAccountScreenName(final Context context) {


### PR DESCRIPTION
This commit fixed the issue that Twidere can't open a status link (e.g. https://twitter.com/a_LYX_z/status/591853546859057152) from browser correctly.