### PR TITLE
Fix user lookup. Fixes #199

### DIFF
--- a/twidere.component.common/src/main/java/org/mariotaku/twidere/api/twitter/api/UsersResources.java
+++ b/twidere.component.common/src/main/java/org/mariotaku/twidere/api/twitter/api/UsersResources.java
@@ -99,10 +99,10 @@ public interface UsersResources {
 
     @POST("/users/lookup.json")
     @Body(BodyType.FORM)
-    ResponseList<User> lookupUsers(@Form("id") long[] ids) throws TwitterException;
+    ResponseList<User> lookupUsers(@Form("user_id") long[] ids) throws TwitterException;
 
     @GET("/users/lookup.json")
-    ResponseList<User> lookupUsers(@Form("id") String[] screenNames) throws TwitterException;
+    ResponseList<User> lookupUsers(@Form("screen_name") String[] screenNames) throws TwitterException;
 
     @POST("/account/remove_profile_banner.json")
     @Body(BodyType.FORM)

--- a/twidere/src/main/java/org/mariotaku/twidere/activity/support/LinkHandlerActivity.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/activity/support/LinkHandlerActivity.java
@@ -503,7 +503,7 @@ public class LinkHandlerActivity extends BaseAppCompatActivity implements System
                 break;
             }
             case LINK_ID_STATUS_FAVORITERS: {
-                setTitle(R.string.users_retweeted_this);
+                setTitle(R.string.users_favorited_this);
                 break;
             }
             case LINK_ID_STATUS_REPLIES: {


### PR DESCRIPTION
Although it seems like /retweeters/ and tweet summaries don't work with all API tokens. I've found that Twitter for iPhone's token works best.