### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/twidere/src/main/java/org/mariotaku/twidere/activity/KeyboardShortcutPreferenceCompatActivity.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/activity/KeyboardShortcutPreferenceCompatActivity.java
@@ -116,6 +116,7 @@ public class KeyboardShortcutPreferenceCompatActivity extends BaseActivity imple
             mConflictLabel.setVisibility(View.VISIBLE);
             final String label = KeyboardShortcutsHandler.getActionLabel(this, oldAction);
             mConflictLabel.setText(getString(R.string.conflicts_with_name, label));
+            //noinspection UnnecessaryParentheses
             mButtonPositive.setText((R.string.overwrite));
         } else if (!TextUtils.isEmpty(oldGeneralAction) && !keyAction.equals(oldGeneralAction)) {
             // Conflicts with keys in root context
@@ -125,7 +126,7 @@ public class KeyboardShortcutPreferenceCompatActivity extends BaseActivity imple
             mButtonPositive.setText((R.string.overwrite));
         } else {
             mConflictLabel.setVisibility(View.GONE);
-            mButtonPositive.setText((android.R.string.ok));
+            mButtonPositive.setText(android.R.string.ok);
         }
         return true;
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableActivitiesAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableActivitiesAdapter.java
@@ -480,7 +480,7 @@ public class ParcelableActivitiesAdapter extends LoadMoreSupportAdapter<Recycler
             final ParcelableActivitiesAdapter adapter = adapterRef.get();
             if (adapter == null) return;
             if (adapter.mActivityAdapterListener != null) {
-                adapter.mActivityAdapterListener.onStatusActionClick(((IStatusViewHolder) holder), id, position);
+                adapter.mActivityAdapterListener.onStatusActionClick((IStatusViewHolder) holder, id, position);
             }
         }
 

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableGroupsAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableGroupsAdapter.java
@@ -163,7 +163,7 @@ public class ParcelableGroupsAdapter extends LoadMoreSupportAdapter<RecyclerView
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         switch (holder.getItemViewType()) {
             case ITEM_VIEW_TYPE_USER_LIST: {
-                bindGroup(((GroupViewHolder) holder), position);
+                bindGroup((GroupViewHolder) holder, position);
                 break;
             }
         }

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableStatusesAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableStatusesAdapter.java
@@ -364,7 +364,7 @@ public abstract class ParcelableStatusesAdapter extends LoadMoreSupportAdapter<R
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         switch (holder.getItemViewType()) {
             case ITEM_VIEW_TYPE_STATUS: {
-                bindStatus(((IStatusViewHolder) holder), position);
+                bindStatus((IStatusViewHolder) holder, position);
                 break;
             }
         }

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableUserListsAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableUserListsAdapter.java
@@ -155,7 +155,7 @@ public class ParcelableUserListsAdapter extends LoadMoreSupportAdapter<RecyclerV
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         switch (holder.getItemViewType()) {
             case ITEM_VIEW_TYPE_USER_LIST: {
-                bindUserList(((UserListViewHolder) holder), position);
+                bindUserList((UserListViewHolder) holder, position);
                 break;
             }
         }

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableUsersAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/ParcelableUsersAdapter.java
@@ -182,7 +182,7 @@ public class ParcelableUsersAdapter extends LoadMoreSupportAdapter<RecyclerView.
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         switch (holder.getItemViewType()) {
             case ITEM_VIEW_TYPE_USER: {
-                bindUser(((UserViewHolder) holder), position);
+                bindUser((UserViewHolder) holder, position);
                 break;
             }
         }

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/VariousItemsAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/VariousItemsAdapter.java
@@ -68,15 +68,15 @@ public class VariousItemsAdapter extends LoadMoreSupportAdapter<RecyclerView.Vie
         final Object obj = mData.get(position);
         switch (getItemViewType(obj)) {
             case VIEW_TYPE_STATUS: {
-                ((StatusViewHolder) holder).displayStatus(((ParcelableStatus) obj), true);
+                ((StatusViewHolder) holder).displayStatus((ParcelableStatus) obj, true);
                 break;
             }
             case VIEW_TYPE_USER: {
-                ((UserViewHolder) holder).displayUser(((ParcelableUser) obj));
+                ((UserViewHolder) holder).displayUser((ParcelableUser) obj);
                 break;
             }
             case VIEW_TYPE_USER_LIST: {
-                ((UserListViewHolder) holder).displayUserList(((ParcelableUserList) obj));
+                ((UserListViewHolder) holder).displayUserList((ParcelableUserList) obj);
                 break;
             }
         }

--- a/twidere/src/main/java/org/mariotaku/twidere/loader/CursorSupportUsersLoader.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/loader/CursorSupportUsersLoader.java
@@ -136,7 +136,7 @@ public abstract class CursorSupportUsersLoader extends TwitterAPIUsersLoader
         } else {
             users = getCursoredUsers(twitter, credentials, paging);
             if (users instanceof CursorSupport) {
-                setCursors(((CursorSupport) users));
+                setCursors((CursorSupport) users);
             }
         }
         incrementPage(users);

--- a/twidere/src/main/java/org/mariotaku/twidere/model/ActivityTitleSummaryMessage.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/ActivityTitleSummaryMessage.java
@@ -297,7 +297,7 @@ public class ActivityTitleSummaryMessage {
     private static Spanned getTitleStringAboutMe(Resources resources, UserColorNameManager manager,
                                                  int stringRes, int stringResMulti,
                                                  ParcelableUser[] sources, boolean nameFirst) {
-        if ((sources == null) || (sources.length == 0)) return null;
+        if (sources == null || sources.length == 0) return null;
         final Configuration configuration = resources.getConfiguration();
         final SpannableString firstDisplayName = new SpannableString(manager.getDisplayName(sources[0],
                 nameFirst));
@@ -323,7 +323,7 @@ public class ActivityTitleSummaryMessage {
     private static Spanned getTitleStringByFriends(Resources resources, UserColorNameManager manager,
                                                    int stringRes, int stringResMulti,
                                                    ParcelableUser[] sources, Object[] targets, boolean nameFirst) {
-        if ((sources == null) || (sources.length == 0)) return null;
+        if (sources == null || sources.length == 0) return null;
         final Configuration configuration = resources.getConfiguration();
         final SpannableString firstSourceName = new SpannableString(manager.getDisplayName(
                 sources[0], nameFirst));

--- a/twidere/src/main/java/org/mariotaku/twidere/preference/DefaultAPIPreference.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/preference/DefaultAPIPreference.java
@@ -159,7 +159,7 @@ public class DefaultAPIPreference extends DialogPreference implements Constants,
         @Override
         public void onDialogClosed(boolean positiveResult) {
             if (!positiveResult) return;
-            DefaultAPIPreference preference = ((DefaultAPIPreference) getPreference());
+            DefaultAPIPreference preference = (DefaultAPIPreference) getPreference();
             final SharedPreferences preferences = preference.getSharedPreferences();
 
             final String apiUrlFormat = ParseUtils.parseString(mEditAPIUrlFormat.getText());

--- a/twidere/src/main/java/org/mariotaku/twidere/util/imageloader/ReadOnlyDiskLRUNameCache.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/imageloader/ReadOnlyDiskLRUNameCache.java
@@ -65,8 +65,8 @@ public class ReadOnlyDiskLRUNameCache extends BaseDiskCache {
     protected File getFile(String imageUri) {
         String fileName = fileNameGenerator.generate(imageUri) + ".0";
         File dir = cacheDir;
-        if ((!cacheDir.exists()) && (!cacheDir.mkdirs()) &&
-                (reserveCacheDir != null) && ((reserveCacheDir.exists()) || (reserveCacheDir.mkdirs()))) {
+        if (!cacheDir.exists() && (!cacheDir.mkdirs()) &&
+                (reserveCacheDir != null) && (reserveCacheDir.exists() || reserveCacheDir.mkdirs())) {
             dir = reserveCacheDir;
         }
         return new File(dir, fileName);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/ActivitySupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/ActivitySupport.java
@@ -48,7 +48,7 @@ public class ActivitySupport {
          * @param colorPrimary A color to override the theme's primary color.  This color must be opaque.
          */
         public TaskDescriptionCompat(String label, Bitmap icon, int colorPrimary) {
-            if ((colorPrimary != 0) && (Color.alpha(colorPrimary) != 255)) {
+            if (colorPrimary != 0 && Color.alpha(colorPrimary) != 255) {
                 throw new RuntimeException("A TaskDescription's primary color should be opaque");
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.