### PR TITLE
Casting math operands before assignment

### DIFF
--- a/twidere/src/main/java/org/mariotaku/twidere/graphic/like/layer/ShineLayerDrawable.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/graphic/like/layer/ShineLayerDrawable.java
@@ -95,8 +95,8 @@ public class ShineLayerDrawable extends AnimationLayerDrawable {
         final ShineLayerState state = (ShineLayerState) mState;
         // Start point: 1/4 of icon radius
         final int fullRadius = state.getFullRadius();
-        startEnd[0] = fullRadius / 3;
-        startEnd[1] = startEnd[0] + (fullRadius / 4 * progress * 4);
+        startEnd[0] = fullRadius / 3F;
+        startEnd[1] = startEnd[0] + (fullRadius / 4F * progress * 4);
     }
 
     /**

--- a/twidere/src/main/java/org/mariotaku/twidere/service/RefreshService.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/service/RefreshService.java
@@ -315,7 +315,7 @@ public class RefreshService extends Service implements Constants {
     private long getRefreshInterval() {
         if (mPreferences == null) return 0;
         final int prefValue = NumberUtils.toInt(mPreferences.getString(KEY_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL), -1);
-        return Math.max(prefValue, 3) * 60 * 1000;
+        return Math.max(prefValue, 3) * 60 * 1000L;
     }
 
     private boolean isHomeTimelineRefreshing() {

--- a/twidere/src/main/java/org/mariotaku/twidere/view/iface/IColorLabelView.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/view/iface/IColorLabelView.java
@@ -146,8 +146,8 @@ public interface IColorLabelView {
             if (colors == null || colors.length == 0) return;
             for (int i = 0, len = colors.length; i < len; i++) {
                 mPaint.setColor(colors[i]);
-                final float colorLeft = left + i * (width / len);
-                final float colorRight = left + (i + 1) * (width / len);
+                final float colorLeft = left + i * (width * 1.0F / len);
+                final float colorRight = left + (i + 1) * (width * 1.0F / len);
                 canvas.drawRect(colorLeft, top, colorRight, top + height, mPaint);
             }
         }
@@ -157,8 +157,8 @@ public interface IColorLabelView {
             if (colors == null || colors.length == 0) return;
             for (int i = 0, len = colors.length; i < len; i++) {
                 mPaint.setColor(colors[i]);
-                final float colorTop = top + i * (height / len);
-                final float colorBottom = top + (i + 1) * (height / len);
+                final float colorTop = top + i * (height * 1.0F / len);
+                final float colorBottom = top + (i + 1) * (height * 1.0F / len);
                 canvas.drawRect(left, colorTop, left + width, colorBottom, mPaint);
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - “Math operands should be cast before assignment”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.