### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/twidere.component.common/src/main/java/com/bluelinelabs/logansquare/Twidere_ParameterizedTypeAccessor.java
+++ b/twidere.component.common/src/main/java/com/bluelinelabs/logansquare/Twidere_ParameterizedTypeAccessor.java
@@ -26,6 +26,9 @@ import java.lang.reflect.Type;
  */
 public class Twidere_ParameterizedTypeAccessor {
 
+    private Twidere_ParameterizedTypeAccessor() {
+    }
+
     public static <T> ParameterizedType<T> create(Type type) {
         return new ParameterizedType.ConcreteParameterizedType<>(type);
     }

--- a/twidere.component.common/src/main/java/org/mariotaku/twidere/util/LoganSquareMapperFinder.java
+++ b/twidere.component.common/src/main/java/org/mariotaku/twidere/util/LoganSquareMapperFinder.java
@@ -23,6 +23,9 @@ import java.util.concurrent.TimeoutException;
 public class LoganSquareMapperFinder {
     private static final ExecutorService pool = Executors.newSingleThreadExecutor();
 
+    private LoganSquareMapperFinder() {
+    }
+
     public static <T> JsonMapper<T> mapperFor(Class<T> cls) throws ClassLoaderDeadLockException {
         return mapperFor(Twidere_ParameterizedTypeAccessor.<T>create(cls));
     }

--- a/twidere.component.common/src/main/java/org/mariotaku/twidere/util/Nullables.java
+++ b/twidere.component.common/src/main/java/org/mariotaku/twidere/util/Nullables.java
@@ -30,6 +30,9 @@ import java.util.List;
  */
 public class Nullables {
 
+    private Nullables() {
+    }
+
     @NonNull
     public static <T> List<T> list(@Nullable List<T> list) {
         if (list == null) return Collections.emptyList();

--- a/twidere.component.common/src/main/java/org/mariotaku/twidere/util/ParseUtils.java
+++ b/twidere.component.common/src/main/java/org/mariotaku/twidere/util/ParseUtils.java
@@ -28,6 +28,8 @@ import java.util.Locale;
 import static android.text.TextUtils.isEmpty;
 
 public final class ParseUtils implements TwidereConstants {
+    private ParseUtils() {
+    }
 
     public static String parseString(final String object) {
         return object;

--- a/twidere.component.common/src/main/java/org/mariotaku/twidere/util/TwitterContentUtils.java
+++ b/twidere.component.common/src/main/java/org/mariotaku/twidere/util/TwitterContentUtils.java
@@ -38,6 +38,9 @@ import java.util.zip.CRC32;
  */
 public class TwitterContentUtils {
 
+    private TwitterContentUtils() {
+    }
+
     public static boolean isOfficialKey(final Context context, final String consumerKey,
                                         final String consumerSecret) {
         if (context == null || consumerKey == null || consumerSecret == null) return false;

--- a/twidere/src/debug/java/org/mariotaku/twidere/util/DebugModeUtils.java
+++ b/twidere/src/debug/java/org/mariotaku/twidere/util/DebugModeUtils.java
@@ -49,6 +49,9 @@ public class DebugModeUtils {
 
     private static RefWatcher sRefWatcher;
 
+    private DebugModeUtils() {
+    }
+
     public static void initForOkHttpClient(final OkHttpClient.Builder builder) {
         final StethoInterceptor interceptor = new StethoInterceptor();
 

--- a/twidere/src/main/java/android/support/v4/app/BackStackEntryAccessor.java
+++ b/twidere/src/main/java/android/support/v4/app/BackStackEntryAccessor.java
@@ -2,6 +2,9 @@ package android.support.v4.app;
 
 public class BackStackEntryAccessor {
 
+	private BackStackEntryAccessor() {
+	}
+
 	public static Fragment getFragmentInBackStackRecord(final FragmentManager.BackStackEntry entry) {
 		if (entry instanceof BackStackRecord) return ((BackStackRecord) entry).mHead.fragment;
 		return null;

--- a/twidere/src/main/java/android/support/v4/app/FragmentAccessor.java
+++ b/twidere/src/main/java/android/support/v4/app/FragmentAccessor.java
@@ -4,6 +4,9 @@ import android.os.Bundle;
 
 public class FragmentAccessor {
 
+	private FragmentAccessor() {
+	}
+
 	public static Bundle getSavedFragmentState(final Fragment f) {
 		return f.mSavedFragmentState;
 	}

--- a/twidere/src/main/java/android/support/v4/app/FragmentManagerAccessor.java
+++ b/twidere/src/main/java/android/support/v4/app/FragmentManagerAccessor.java
@@ -4,6 +4,9 @@ import android.support.v4.view.LayoutInflaterFactory;
 
 public class FragmentManagerAccessor {
 
+    private FragmentManagerAccessor() {
+    }
+
     public static boolean isStateSaved(final FragmentManager fm) {
         if (fm instanceof FragmentManagerImpl) return ((FragmentManagerImpl) fm).mStateSaved;
         return false;

--- a/twidere/src/main/java/android/support/v4/content/LoaderAccessor.java
+++ b/twidere/src/main/java/android/support/v4/content/LoaderAccessor.java
@@ -23,6 +23,9 @@ package android.support.v4.content;
  * Created by mariotaku on 15/7/5.
  */
 public class LoaderAccessor {
+    private LoaderAccessor() {
+    }
+
     public static <T> boolean isContentChanged(final Loader<T> loader) {
         return loader.mContentChanged;
     }

--- a/twidere/src/main/java/android/support/v4/widget/DrawerLayoutAccessor.java
+++ b/twidere/src/main/java/android/support/v4/widget/DrawerLayoutAccessor.java
@@ -26,6 +26,9 @@ import android.view.View;
  */
 public class DrawerLayoutAccessor {
 
+    private DrawerLayoutAccessor() {
+    }
+
     public static View findDrawerWithGravity(DrawerLayout layout, int gravity) {
         return layout.findDrawerWithGravity(gravity);
     }

--- a/twidere/src/main/java/edu/tsinghua/hotmobi/util/LocationUtils.java
+++ b/twidere/src/main/java/edu/tsinghua/hotmobi/util/LocationUtils.java
@@ -20,6 +20,9 @@ import edu.tsinghua.hotmobi.model.LatLng;
  * Created by mariotaku on 16/1/29.
  */
 public class LocationUtils implements HotMobiConstants, Constants {
+    private LocationUtils() {
+    }
+
     public static LatLng getCachedLatLng(final Context context) {
         final Context appContext = context.getApplicationContext();
         final SharedPreferences prefs = DependencyHolder.get(context).getPreferences();

--- a/twidere/src/main/java/edu/tsinghua/hotmobi/util/TwidereDataUtils.java
+++ b/twidere/src/main/java/edu/tsinghua/hotmobi/util/TwidereDataUtils.java
@@ -32,6 +32,9 @@ import edu.tsinghua.hotmobi.model.TweetType;
 
 public class TwidereDataUtils {
 
+    private TwidereDataUtils() {
+    }
+
     public static String getLinkType(int type) {
         switch (type) {
             case TwidereLinkify.LINK_TYPE_MENTION:

--- a/twidere/src/main/java/org/mariotaku/twidere/adapter/iface/ILoadMoreSupportAdapter.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/adapter/iface/ILoadMoreSupportAdapter.java
@@ -47,6 +47,9 @@ public interface ILoadMoreSupportAdapter {
     }
 
     class IndicatorPositionUtils {
+        private IndicatorPositionUtils() {
+        }
+
         @IndicatorPosition
         public static int apply(@IndicatorPosition int orig, @IndicatorPosition int supported) {
             return orig & supported;

--- a/twidere/src/main/java/org/mariotaku/twidere/api/twitter/util/JSONObjectType.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/api/twitter/util/JSONObjectType.java
@@ -26,6 +26,9 @@ import com.fasterxml.jackson.core.TreeNode;
  * @since Twitter4J 2.1.9
  */
 public final class JSONObjectType {
+    private JSONObjectType() {
+    }
+
     public enum Type {
         SENDER,
         STATUS,

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableAccountUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableAccountUtils.java
@@ -23,6 +23,9 @@ import java.util.List;
  */
 public class ParcelableAccountUtils {
 
+    private ParcelableAccountUtils() {
+    }
+
     public static UserKey[] getAccountKeys(@NonNull ParcelableAccount[] accounts) {
         UserKey[] ids = new UserKey[accounts.length];
         for (int i = 0, j = accounts.length; i < j; i++) {

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableActivityUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableActivityUtils.java
@@ -20,6 +20,9 @@ import java.util.List;
  */
 public class ParcelableActivityUtils {
 
+    private ParcelableActivityUtils() {
+    }
+
     /**
      * @param activity        Activity for processing
      * @param filteredUserIds Those ids will be removed from source_ids.

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableCredentialsUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableCredentialsUtils.java
@@ -15,6 +15,9 @@ import org.mariotaku.twidere.util.DataStoreUtils;
  * Created by mariotaku on 16/3/4.
  */
 public class ParcelableCredentialsUtils {
+    private ParcelableCredentialsUtils() {
+    }
+
     public static boolean isOAuth(int authType) {
         switch (authType) {
             case ParcelableCredentials.AuthType.OAUTH:

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableDirectMessageUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableDirectMessageUtils.java
@@ -16,6 +16,9 @@ import static org.mariotaku.twidere.util.HtmlEscapeHelper.toPlainText;
  */
 public class ParcelableDirectMessageUtils {
 
+    private ParcelableDirectMessageUtils() {
+    }
+
     public static ParcelableDirectMessage fromDirectMessage(DirectMessage message, UserKey accountKey, boolean isOutgoing) {
         ParcelableDirectMessage result = new ParcelableDirectMessage();
         result.account_key = accountKey;

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableGroupUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableGroupUtils.java
@@ -10,6 +10,9 @@ import java.util.Date;
  * Created by mariotaku on 16/3/9.
  */
 public class ParcelableGroupUtils {
+    private ParcelableGroupUtils() {
+    }
+
     public static ParcelableGroup from(Group group, UserKey accountKey, int position, boolean member) {
         ParcelableGroup obj = new ParcelableGroup();
         obj.account_key = accountKey;

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableLocationUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableLocationUtils.java
@@ -11,6 +11,9 @@ import org.mariotaku.twidere.util.InternalParseUtils;
  * Created by mariotaku on 16/3/8.
  */
 public class ParcelableLocationUtils {
+    private ParcelableLocationUtils() {
+    }
+
     public static String getHumanReadableString(ParcelableLocation obj, int decimalDigits) {
         return String.format("%s,%s", InternalParseUtils.parsePrettyDecimal(obj.latitude, decimalDigits),
                 InternalParseUtils.parsePrettyDecimal(obj.longitude, decimalDigits));

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableMediaUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableMediaUtils.java
@@ -28,6 +28,9 @@ import java.util.List;
  * Created by mariotaku on 16/2/13.
  */
 public class ParcelableMediaUtils {
+    private ParcelableMediaUtils() {
+    }
+
     @NonNull
     public static ParcelableMedia[] fromEntities(@Nullable final EntitySupport entities) {
         if (entities == null) return new ParcelableMedia[0];

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableStatusUpdateUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableStatusUpdateUtils.java
@@ -11,6 +11,8 @@ import org.mariotaku.twidere.model.draft.UpdateStatusActionExtra;
  * Created by mariotaku on 16/2/12.
  */
 public class ParcelableStatusUpdateUtils implements Constants {
+    private ParcelableStatusUpdateUtils() {
+    }
 
     public static ParcelableStatusUpdate fromDraftItem(final Context context, final Draft draft) {
         ParcelableStatusUpdate statusUpdate = new ParcelableStatusUpdate();

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableStatusUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableStatusUtils.java
@@ -32,6 +32,8 @@ import java.util.List;
  * Created by mariotaku on 16/1/3.
  */
 public class ParcelableStatusUtils implements Constants {
+    private ParcelableStatusUtils() {
+    }
 
     public static void makeOriginalStatus(@NonNull ParcelableStatus status) {
         if (!status.is_retweet) return;

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableUserListUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableUserListUtils.java
@@ -12,6 +12,9 @@ import org.mariotaku.twidere.util.TwitterContentUtils;
  * Created by mariotaku on 16/3/5.
  */
 public class ParcelableUserListUtils {
+    private ParcelableUserListUtils() {
+    }
+
     public static ParcelableUserList from(UserList list, UserKey accountKey) {
         return from(list, accountKey, 0, false);
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableUserMentionUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableUserMentionUtils.java
@@ -9,6 +9,9 @@ import org.mariotaku.twidere.model.UserKey;
  * Created by mariotaku on 16/3/7.
  */
 public class ParcelableUserMentionUtils {
+    private ParcelableUserMentionUtils() {
+    }
+
     public static ParcelableUserMention fromMentionEntity(final User user,
                                                           final UserMentionEntity entity) {
         ParcelableUserMention obj = new ParcelableUserMention();

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableUserUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/ParcelableUserUtils.java
@@ -24,6 +24,8 @@ import org.mariotaku.twidere.util.UserColorNameManager;
  * Created by mariotaku on 16/2/24.
  */
 public class ParcelableUserUtils implements TwidereConstants {
+    private ParcelableUserUtils() {
+    }
 
     public static ParcelableUser fromUser(@NonNull User user, @Nullable UserKey accountKey) {
         return fromUser(user, accountKey, 0);

--- a/twidere/src/main/java/org/mariotaku/twidere/model/util/UserKeyUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/model/util/UserKeyUtils.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
  */
 public class UserKeyUtils {
 
+    private UserKeyUtils() {
+    }
+
     @Nullable
     public static UserKey findById(Context context, String id) {
         final String[] projection = {Accounts.ACCOUNT_KEY};

--- a/twidere/src/main/java/org/mariotaku/twidere/util/AsyncTaskUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/AsyncTaskUtils.java
@@ -32,6 +32,9 @@ public class AsyncTaskUtils {
 
     public static final Executor DEFAULT_EXECUTOR = Executors.newFixedThreadPool(2);
 
+    private AsyncTaskUtils() {
+    }
+
     @SafeVarargs
     public static <T extends AsyncTask<Parameter, ?, ?>, Parameter> T executeTask(T task, Parameter... params) {
         task.executeOnExecutor(DEFAULT_EXECUTOR, params);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/BitmapDecodeHelper.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/BitmapDecodeHelper.java
@@ -25,6 +25,9 @@ import android.graphics.Matrix;
 
 public class BitmapDecodeHelper {
 
+	private BitmapDecodeHelper() {
+	}
+
 	public static Bitmap decode(final String path, final BitmapFactory.Options opts) {
 		if (path == null || opts == null) return null;
 		final Bitmap bm = BitmapFactory.decodeFile(path, opts);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/BitmapUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/BitmapUtils.java
@@ -36,6 +36,9 @@ import java.io.FileOutputStream;
 
 public class BitmapUtils {
 
+    private BitmapUtils() {
+    }
+
     // Find the max x that 1 / x <= scale.
     public static int computeSampleSize(final float scale) {
         if (scale <= 0) return 1;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/CheckUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/CheckUtils.java
@@ -27,6 +27,9 @@ import android.text.TextUtils;
  * Created by mariotaku on 15/11/22.
  */
 public class CheckUtils {
+    private CheckUtils() {
+    }
+
     public static boolean checkRange(@Nullable final CharSequence text, int start, int end) {
         if (text == null) return false;
 

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ClipboardUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ClipboardUtils.java
@@ -30,6 +30,9 @@ import android.text.style.ImageSpan;
 
 public final class ClipboardUtils {
 
+    private ClipboardUtils() {
+    }
+
     public static boolean setText(final Context context, final CharSequence text) {
         if (context == null) return false;
         final ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
@@ -44,6 +47,8 @@ public final class ClipboardUtils {
     }
 
     private static class ClipboardUtilsAPI16 {
+        private ClipboardUtilsAPI16() {
+        }
 
         @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
         public static String getImageUrl(final Context context) {

--- a/twidere/src/main/java/org/mariotaku/twidere/util/CollectionUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/CollectionUtils.java
@@ -26,6 +26,9 @@ import java.util.Collection;
  */
 public class CollectionUtils {
 
+    private CollectionUtils() {
+    }
+
     public static <T> String toString(final Collection<T> collection, final char token, final boolean includeSpace) {
         final StringBuilder builder = new StringBuilder();
         int i = 0;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/CompareUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/CompareUtils.java
@@ -25,6 +25,9 @@ import org.apache.commons.lang3.ArrayUtils;
 
 public class CompareUtils {
 
+    private CompareUtils() {
+    }
+
     public static boolean bundleEquals(final Bundle bundle1, final Bundle bundle2, final String... ignoredKeys) {
         if (bundle1 == null || bundle2 == null) return bundle1 == bundle2;
         for (String key : bundle1.keySet()) {

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ContentValuesCreator.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ContentValuesCreator.java
@@ -64,6 +64,8 @@ import java.util.List;
 import static org.mariotaku.twidere.util.HtmlEscapeHelper.toPlainText;
 
 public final class ContentValuesCreator implements TwidereConstants {
+    private ContentValuesCreator() {
+    }
 
     public static ContentValues createCachedRelationship(final Relationship relationship,
                                                          final UserKey accountKey,

--- a/twidere/src/main/java/org/mariotaku/twidere/util/CustomTabUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/CustomTabUtils.java
@@ -137,6 +137,9 @@ public class CustomTabUtils implements Constants {
         CUSTOM_TABS_ICON_NAME_MAP.put("user", R.drawable.ic_action_user);
     }
 
+    private CustomTabUtils() {
+    }
+
     public static String findTabIconKey(final int iconRes) {
         for (final Entry<String, Integer> entry : getIconMap().entrySet()) {
             if (entry.getValue() == iconRes) return entry.getKey();

--- a/twidere/src/main/java/org/mariotaku/twidere/util/EmojiSupportUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/EmojiSupportUtils.java
@@ -34,6 +34,9 @@ import org.mariotaku.twidere.text.util.EmojiSpannableFactory;
  */
 public class EmojiSupportUtils {
 
+    private EmojiSupportUtils() {
+    }
+
     public static void initForTextView(TextView textView) {
         if (textView.isInEditMode()) return;
         textView.setSpannableFactory(new EmojiSpannableFactory(textView));

--- a/twidere/src/main/java/org/mariotaku/twidere/util/FileUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/FileUtils.java
@@ -41,6 +41,9 @@ public final class FileUtils {
      */
     private static final long FILE_COPY_BUFFER_SIZE = ONE_MB * 30;
 
+    private FileUtils() {
+    }
+
     /**
      * Copies a file to a new location preserving the file date.
      * <p/>

--- a/twidere/src/main/java/org/mariotaku/twidere/util/HtmlEscapeHelper.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/HtmlEscapeHelper.java
@@ -34,6 +34,9 @@ public class HtmlEscapeHelper {
             new UnicodeControlCharacterToHtmlTranslator());
     public static final LookupTranslator ESCAPE_BASIC = new LookupTranslator(EntityArrays.BASIC_ESCAPE());
 
+    private HtmlEscapeHelper() {
+    }
+
     public static String escape(final CharSequence text) {
         if (text == null) return null;
         return ESCAPE_HTML.translate(text);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/HtmlSpanBuilder.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/HtmlSpanBuilder.java
@@ -46,6 +46,9 @@ public class HtmlSpanBuilder {
 
     private static final IAttoParser PARSER = new MarkupAttoParser();
 
+    private HtmlSpanBuilder() {
+    }
+
     public static Spannable fromHtml(String html) throws ParseException {
         final HtmlParsingConfiguration conf = new HtmlParsingConfiguration();
         final HtmlSpanHandler handler = new HtmlSpanHandler(conf);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/HttpClientFactory.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/HttpClientFactory.java
@@ -30,6 +30,8 @@ import static android.text.TextUtils.isEmpty;
  * Created by mariotaku on 16/1/27.
  */
 public class HttpClientFactory implements Constants {
+    private HttpClientFactory() {
+    }
 
     public static RestHttpClient createRestHttpClient(final Context context,
                                                       final SharedPreferencesWrapper prefs, final Dns dns,

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ImageLoaderUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ImageLoaderUtils.java
@@ -31,6 +31,9 @@ import java.io.File;
  */
 public class ImageLoaderUtils {
 
+	private ImageLoaderUtils() {
+	}
+
 	/**
 	 * Get the size in bytes of a bitmap.
 	 * 
@@ -82,6 +85,9 @@ public class ImageLoaderUtils {
 
 	static class GetBitmapSizeAccessor {
 
+		private GetBitmapSizeAccessor() {
+		}
+
 		@TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
 		static int getBitmapSize(final Bitmap bitmap) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) return bitmap.getByteCount();
@@ -92,6 +98,9 @@ public class ImageLoaderUtils {
 
 	static class GetMemoryClassAccessor {
 
+		private GetMemoryClassAccessor() {
+		}
+
 		@TargetApi(Build.VERSION_CODES.ECLAIR)
 		public static int getMemoryClass(final Context context) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR)
@@ -101,6 +110,9 @@ public class ImageLoaderUtils {
 	}
 
 	static class GetUsableSpaceAccessor {
+
+		private GetUsableSpaceAccessor() {
+		}
 
 		@SuppressWarnings("deprecation")
 		@TargetApi(Build.VERSION_CODES.GINGERBREAD)

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ImageValidator.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ImageValidator.java
@@ -44,6 +44,9 @@ public class ImageValidator {
     private static final byte[] JPEG_HEAD = {(byte) 0xFF, (byte) 0xD8};
     private static final byte[] JPEG_TAIL = {(byte) 0xFF, (byte) 0xD9};
 
+    private ImageValidator() {
+    }
+
     public static boolean isValidForRegionDecoder(int validity) {
         return (validity & VALID_FOR_REGION_DECODER) != 0;
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/IntentUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/IntentUtils.java
@@ -44,6 +44,9 @@ import static android.text.TextUtils.isEmpty;
  * Created by mariotaku on 16/1/2.
  */
 public class IntentUtils implements Constants {
+    private IntentUtils() {
+    }
+
     public static String getStatusShareText(@NonNull final Context context, @NonNull final ParcelableStatus status) {
         final Uri link = LinkCreator.getStatusWebLink(status);
         return context.getString(R.string.status_share_text_format_with_link,

--- a/twidere/src/main/java/org/mariotaku/twidere/util/InternalParseUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/InternalParseUtils.java
@@ -16,6 +16,9 @@ import java.util.Set;
  * Created by mariotaku on 16/3/8.
  */
 public class InternalParseUtils {
+    private InternalParseUtils() {
+    }
+
     public static String bundleToJSON(final Bundle args) {
         final Set<String> keys = args.keySet();
         final StringWriter sw = new StringWriter();

--- a/twidere/src/main/java/org/mariotaku/twidere/util/InternalTwitterContentUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/InternalTwitterContentUtils.java
@@ -41,6 +41,9 @@ public class InternalTwitterContentUtils {
     private static final CharSequenceTranslator UNESCAPE_TWITTER_RAW_TEXT = new LookupTranslator(EntityArrays.BASIC_UNESCAPE());
     private static final CharSequenceTranslator ESCAPE_TWITTER_RAW_TEXT = new LookupTranslator(EntityArrays.BASIC_ESCAPE());
 
+    private InternalTwitterContentUtils() {
+    }
+
     public static <T extends List<? extends Status>> T getStatusesWithQuoteData(Twitter twitter, @NonNull T list) throws TwitterException {
         MultiValueMap<Status> quotes = new MultiValueMap<>();
         // Phase 1: collect all statuses contains a status link, and put it in the map

--- a/twidere/src/main/java/org/mariotaku/twidere/util/JsonSerializer.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/JsonSerializer.java
@@ -37,6 +37,9 @@ import java.util.Map;
  */
 public class JsonSerializer {
 
+    private JsonSerializer() {
+    }
+
     @Nullable
     public static <T> String serialize(@Nullable final List<T> list, final Class<T> cls) {
         if (list == null) return null;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/LinkCreator.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/LinkCreator.java
@@ -37,6 +37,9 @@ public class LinkCreator implements Constants {
     private static final String AUTHORITY_TWITTER = "twitter.com";
     private static final String AUTHORITY_FANFOU = "fanfou.com";
 
+    private LinkCreator() {
+    }
+
     public static Uri getTwidereStatusLink(UserKey accountKey, @NonNull String statusId) {
         final Uri.Builder builder = new Uri.Builder();
         builder.scheme(SCHEME_TWIDERE);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ListViewUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ListViewUtils.java
@@ -27,6 +27,9 @@ import android.widget.ListView;
  */
 public class ListViewUtils {
 
+    private ListViewUtils() {
+    }
+
     public static int getFirstFullyVisiblePosition(final ListView listView) {
         final int firstVisiblePosition = listView.getFirstVisiblePosition();
         final View firstVisibleChild = listView.getChildAt(0);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/LongSparseArrayUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/LongSparseArrayUtils.java
@@ -22,6 +22,9 @@ package org.mariotaku.twidere.util;
 import android.support.v4.util.LongSparseArray;
 
 public class LongSparseArrayUtils {
+	private LongSparseArrayUtils() {
+	}
+
 	/**
 	 * @return A copy of all keys contained in the sparse array.
 	 */

--- a/twidere/src/main/java/org/mariotaku/twidere/util/MenuUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/MenuUtils.java
@@ -67,6 +67,9 @@ import java.util.List;
  * Created by mariotaku on 15/4/12.
  */
 public class MenuUtils implements Constants {
+    private MenuUtils() {
+    }
+
     public static void setMenuItemAvailability(final Menu menu, final int id, final boolean available) {
         if (menu == null) return;
         final MenuItem item = menu.findItem(id);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ParcelUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ParcelUtils.java
@@ -11,6 +11,9 @@ import java.lang.reflect.Field;
  */
 public class ParcelUtils {
 
+    private ParcelUtils() {
+    }
+
     public static <T extends Parcelable> T clone(@NonNull T object) {
         final Parcel parcel = Parcel.obtain();
         try {

--- a/twidere/src/main/java/org/mariotaku/twidere/util/PermissionUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/PermissionUtils.java
@@ -29,6 +29,9 @@ import org.apache.commons.lang3.ArrayUtils;
  * Created by mariotaku on 15/10/8.
  */
 public class PermissionUtils {
+    private PermissionUtils() {
+    }
+
     public static int getPermission(String[] permissions, int[] grantResults, String permission) {
         final int idx = ArrayUtils.indexOf(permissions, permission);
         if (idx != -1) return grantResults[idx];

--- a/twidere/src/main/java/org/mariotaku/twidere/util/RecyclerViewUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/RecyclerViewUtils.java
@@ -30,6 +30,9 @@ import android.view.ViewParent;
  */
 public class RecyclerViewUtils {
 
+    private RecyclerViewUtils() {
+    }
+
     public static View findRecyclerViewChild(RecyclerView recyclerView, View view) {
         if (view == null) return null;
         final ViewParent parent = view.getParent();

--- a/twidere/src/main/java/org/mariotaku/twidere/util/RegexUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/RegexUtils.java
@@ -25,6 +25,9 @@ import java.util.regex.Matcher;
  * Created by mariotaku on 15/1/11.
  */
 public class RegexUtils {
+    private RegexUtils() {
+    }
+
     public static int matcherEnd(final Matcher matcher, final int group) {
         try {
             return matcher.end(group);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/ServiceUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/ServiceUtils.java
@@ -34,6 +34,9 @@ public final class ServiceUtils implements Constants {
 
     private static HashMap<Context, ServiceUtils.ServiceBinder> sConnectionMap = new HashMap<>();
 
+    private ServiceUtils() {
+    }
+
     public static ServiceToken bindToService(final Context context, final Intent intent) {
         return bindToService(context, intent, null);
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/StatusCodeMessageUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/StatusCodeMessageUtils.java
@@ -54,6 +54,9 @@ public class StatusCodeMessageUtils {
         HTTP_STATUS_CODE_MESSAGES.put(407, R.string.error_http_407);
     }
 
+    private StatusCodeMessageUtils() {
+    }
+
     public static boolean containsHttpStatus(final int code) {
         return HTTP_STATUS_CODE_MESSAGES.get(code, -1) != -1;
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/StrictModeUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/StrictModeUtils.java
@@ -31,6 +31,9 @@ public class StrictModeUtils {
     public static final String LOGTAG = "Twidere.StrictMode";
     public static final String CLASS_NAME = StrictModeUtils.class.getName();
 
+    private StrictModeUtils() {
+    }
+
     public static void checkDiskIO() {
         check("Disk IO");
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TransitionUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TransitionUtils.java
@@ -39,6 +39,9 @@ import android.view.View;
 public class TransitionUtils {
     private static int MAX_IMAGE_SIZE = (1024 * 1024);
 
+    private TransitionUtils() {
+    }
+
     static Animator mergeAnimators(Animator animator1, Animator animator2) {
         if (animator1 == null) {
             return animator2;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereCollectionUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereCollectionUtils.java
@@ -6,6 +6,9 @@ import java.util.Collection;
  * Created by mariotaku on 16/3/7.
  */
 public class TwidereCollectionUtils {
+    private TwidereCollectionUtils() {
+    }
+
     public static String[] toStringArray(final Collection<?> list) {
         if (list == null) return null;
         final int length = list.size();

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereColorUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereColorUtils.java
@@ -32,6 +32,9 @@ import android.graphics.Rect;
  */
 public class TwidereColorUtils {
 
+    private TwidereColorUtils() {
+    }
+
     public static Bitmap getColorPreviewBitmap(final Context context, final int color, final boolean border) {
         if (context == null) return null;
         final float density = context.getResources().getDisplayMetrics().density;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereListUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereListUtils.java
@@ -24,6 +24,9 @@ import java.util.List;
 
 public class TwidereListUtils {
 
+    private TwidereListUtils() {
+    }
+
     public static List<Long> fromArray(final long[] array) {
         if (array == null) return null;
         final List<Long> list = new ArrayList<>();

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereMathUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereMathUtils.java
@@ -29,6 +29,9 @@ public class TwidereMathUtils {
     static final int MASK_LEFT_BOUND = 0b10;
     static final int MASK_RIGHT_BOUND = 0b01;
 
+    private TwidereMathUtils() {
+    }
+
     public static float clamp(final float num, final float bound1, final float bound2) {
         final float max = Math.max(bound1, bound2), min = Math.min(bound1, bound2);
         return Math.max(Math.min(num, max), min);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereQueryBuilder.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereQueryBuilder.java
@@ -47,6 +47,9 @@ public class TwidereQueryBuilder {
 
     public static final class CachedUsersQueryBuilder {
 
+        private CachedUsersQueryBuilder() {
+        }
+
         public static Pair<SQLSelectQuery, String[]> withRelationship(final String[] projection,
                                                                       final String selection,
                                                                       final String[] selectionArgs,
@@ -152,6 +155,9 @@ public class TwidereQueryBuilder {
 
     public static final class ConversationQueryBuilder {
 
+        private ConversationQueryBuilder() {
+        }
+
         public static Pair<SQLSelectQuery, String[]> buildByConversationId(final String[] projection,
                                                                            final UserKey accountKey,
                                                                            final String conversationId,
@@ -198,6 +204,9 @@ public class TwidereQueryBuilder {
     }
 
     public static class ConversationsEntryQueryBuilder {
+
+        private ConversationsEntryQueryBuilder() {
+        }
 
         public static SQLSelectQuery build() {
             return build(null);
@@ -276,6 +285,9 @@ public class TwidereQueryBuilder {
     }
 
     public static final class DirectMessagesQueryBuilder {
+
+        private DirectMessagesQueryBuilder() {
+        }
 
         public static SQLSelectQuery build() {
             return build(null, null, null);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereStringUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereStringUtils.java
@@ -30,6 +30,9 @@ import android.text.style.ReplacementSpan;
  * Created by mariotaku on 14/12/23.
  */
 public class TwidereStringUtils {
+    private TwidereStringUtils() {
+    }
+
     public static boolean regionMatchesIgnoreCase(@NonNull final String string, final int thisStart,
                                                   @NonNull final String match, final int start,
                                                   final int length) {

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereTypeUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereTypeUtils.java
@@ -8,6 +8,9 @@ import java.lang.reflect.Type;
  */
 public class TwidereTypeUtils {
 
+    private TwidereTypeUtils() {
+    }
+
     public static String toSimpleName(Type type) {
         final StringBuilder sb = new StringBuilder();
         buildSimpleName(type, sb);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwidereViewUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwidereViewUtils.java
@@ -7,6 +7,9 @@ import android.view.View;
  * Created by mariotaku on 16/1/23.
  */
 public class TwidereViewUtils {
+    private TwidereViewUtils() {
+    }
+
     @UiThread
     public static boolean hitView(float x, float y, View view) {
         int[] location = new int[2];

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwitterAPIFactory.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwitterAPIFactory.java
@@ -88,6 +88,9 @@ public class TwitterAPIFactory implements TwidereConstants {
         sConstantPoll.put("include_ext_alt_text", "true");
     }
 
+    private TwitterAPIFactory() {
+    }
+
     @WorkerThread
     public static Twitter getDefaultTwitterInstance(final Context context, final boolean includeEntities) {
         if (context == null) return null;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/TwitterCardUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/TwitterCardUtils.java
@@ -42,6 +42,9 @@ public class TwitterCardUtils {
     public static final String CARD_NAME_AUDIO = "audio";
     public static final String CARD_NAME_ANIMATED_GIF = "animated_gif";
 
+    private TwitterCardUtils() {
+    }
+
     @Nullable
     public static Fragment createCardFragment(ParcelableStatus status) {
         final ParcelableCardEntity card = status.card;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/UnitConvertUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/UnitConvertUtils.java
@@ -12,6 +12,9 @@ public class UnitConvertUtils {
 
     public static final String[] countUnits = {null, "K", "M", "B"};
 
+    private UnitConvertUtils() {
+    }
+
     public static String calculateProperSize(double bytes) {
         double value = bytes;
         int index;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/UnreadCountUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/UnreadCountUtils.java
@@ -29,6 +29,8 @@ import org.mariotaku.twidere.provider.TwidereDataStore;
 import org.mariotaku.twidere.provider.TwidereDataStore.UnreadCounts;
 
 public class UnreadCountUtils implements Constants {
+	private UnreadCountUtils() {
+	}
 
 	public static int getUnreadCount(final Context context, final int position) {
 		if (context == null || position < 0) return 0;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/UriExtraUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/UriExtraUtils.java
@@ -29,6 +29,8 @@ import java.util.List;
  * Created by mariotaku on 15/10/20.
  */
 public class UriExtraUtils implements Constants {
+    private UriExtraUtils() {
+    }
 
     public static void addExtra(Uri.Builder builder, String key, Object value) {
         builder.appendQueryParameter(QUERY_PARAM_EXTRA, key + "=" + String.valueOf(value));

--- a/twidere/src/main/java/org/mariotaku/twidere/util/UriUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/UriUtils.java
@@ -28,6 +28,9 @@ import android.support.annotation.Nullable;
  */
 public class UriUtils {
 
+    private UriUtils() {
+    }
+
     public static Uri appendQueryParameters(final Uri uri, final String key, long value) {
         return appendQueryParameters(uri, key, ParseUtils.parseString(value));
     }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/UserAgentUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/UserAgentUtils.java
@@ -36,6 +36,9 @@ import java.lang.reflect.Constructor;
  * Created by mariotaku on 15/4/12.
  */
 public class UserAgentUtils {
+    private UserAgentUtils() {
+    }
+
     // You may uncomment next line if using Android Annotations library, otherwise just be sure to run it in on the UI thread
     @UiThread
     public static String getDefaultUserAgentString(Context context) {
@@ -114,6 +117,9 @@ public class UserAgentUtils {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     static class NewApiWrapper {
+        private NewApiWrapper() {
+        }
+
         @UiThread
         static String getDefaultUserAgent(Context context) {
             return WebSettings.getDefaultUserAgent(context);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/Utils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/Utils.java
@@ -2225,6 +2225,9 @@ public final class Utils implements Constants {
 
     static class UtilsL {
 
+        private UtilsL() {
+        }
+
         @TargetApi(Build.VERSION_CODES.LOLLIPOP)
         static void setSharedElementTransition(Context context, Window window, int transitionRes) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/content/ContentResolverUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/content/ContentResolverUtils.java
@@ -37,6 +37,9 @@ public class ContentResolverUtils {
 
     public static final int MAX_BULK_COUNT = 128;
 
+    private ContentResolverUtils() {
+    }
+
     public static <T> int bulkDelete(@NonNull final ContentResolver resolver, @NonNull final Uri uri,
                                      @NonNull final String inColumn, final Collection<T> colValues,
                                      final String extraWhere) {

--- a/twidere/src/main/java/org/mariotaku/twidere/util/content/DatabaseUpgradeHelper.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/content/DatabaseUpgradeHelper.java
@@ -50,6 +50,9 @@ import static org.mariotaku.sqliteqb.library.SQLQueryBuilder.select;
 
 public final class DatabaseUpgradeHelper {
 
+    private DatabaseUpgradeHelper() {
+    }
+
     public static void safeUpgrade(final SQLiteDatabase db, final String table, final String[] newColNames,
                                    final String[] newColTypes, final boolean dropDirectly,
                                    final Map<String, String> colAliases, final OnConflict onConflict,

--- a/twidere/src/main/java/org/mariotaku/twidere/util/dagger/GeneralComponentHelper.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/dagger/GeneralComponentHelper.java
@@ -28,6 +28,9 @@ import android.support.annotation.NonNull;
 public class GeneralComponentHelper {
     private static GeneralComponent sGeneralComponent;
 
+    private GeneralComponentHelper() {
+    }
+
     @NonNull
     public static GeneralComponent build(@NonNull Context context) {
         if (sGeneralComponent != null) return sGeneralComponent;

--- a/twidere/src/main/java/org/mariotaku/twidere/util/media/preview/PreviewMediaExtractor.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/media/preview/PreviewMediaExtractor.java
@@ -27,6 +27,9 @@ public class PreviewMediaExtractor {
             new TwitterMediaProvider()
     };
 
+    private PreviewMediaExtractor() {
+    }
+
     @Nullable
     public static ParcelableMedia fromLink(@NonNull String link) {
         final Provider provider = providerFor(link);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/ActivitySupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/ActivitySupport.java
@@ -15,6 +15,9 @@ import android.os.Parcelable;
  */
 public class ActivitySupport {
 
+    private ActivitySupport() {
+    }
+
     public static void setTaskDescription(Activity activity, TaskDescriptionCompat taskDescription) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
         ActivityAccessorL.setTaskDescription(activity, taskDescription);
@@ -22,6 +25,9 @@ public class ActivitySupport {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     static class ActivityAccessorL {
+        private ActivityAccessorL() {
+        }
+
         public static void setTaskDescription(Activity activity, TaskDescriptionCompat taskDescription) {
             activity.setTaskDescription(toNativeTaskDescription(taskDescription));
         }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/DrawableSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/DrawableSupport.java
@@ -30,6 +30,9 @@ import org.mariotaku.twidere.util.support.graphics.OutlineCompat;
  */
 public class DrawableSupport {
 
+    private DrawableSupport() {
+    }
+
     public static void getOutline(Drawable drawable, OutlineCompat outlineCompat) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
         DrawableSupportLollipop.getOutline(drawable, outlineCompat);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/IntentSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/IntentSupport.java
@@ -31,6 +31,9 @@ public class IntentSupport {
     @SuppressLint("InlinedApi")
     public static final String CATEGORY_APP_BROWSER = Intent.CATEGORY_APP_BROWSER;
 
+    private IntentSupport() {
+    }
+
     public static void setSelector(Intent intent, Intent selector) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) return;
         IntentSupport15.setSelector(intent, selector);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/SpannableStringBuilderSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/SpannableStringBuilderSupport.java
@@ -7,6 +7,9 @@ import android.text.SpannableStringBuilder;
  */
 public class SpannableStringBuilderSupport {
 
+    private SpannableStringBuilderSupport() {
+    }
+
     public static void append(SpannableStringBuilder builder, CharSequence text, Object span, int flags) {
         int start = builder.length();
         builder.append(text);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/TextViewSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/TextViewSupport.java
@@ -28,6 +28,9 @@ import android.widget.TextView;
  * Created by mariotaku on 15/5/3.
  */
 public class TextViewSupport {
+    private TextViewSupport() {
+    }
+
     public static Drawable[] getCompoundDrawablesRelative(TextView view) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
             return view.getCompoundDrawables();

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/ViewSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/ViewSupport.java
@@ -36,6 +36,9 @@ import org.mariotaku.twidere.view.iface.IForegroundView;
 
 public final class ViewSupport {
 
+    private ViewSupport() {
+    }
+
     public static boolean isInLayout(View view) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
             return false;
@@ -128,6 +131,9 @@ public final class ViewSupport {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     static class ViewAccessorJB {
+        private ViewAccessorJB() {
+        }
+
         static void setBackground(final View view, final Drawable background) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) return;
             view.setBackground(background);
@@ -136,6 +142,9 @@ public final class ViewSupport {
 
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     static class ViewAccessorICS {
+        private ViewAccessorICS() {
+        }
+
         static void setForeground(final View view, final Drawable foreground) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) return;
             if (view instanceof FrameLayout) {
@@ -150,6 +159,9 @@ public final class ViewSupport {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     static class ViewAccessorJBMR2 {
+        private ViewAccessorJBMR2() {
+        }
+
         static boolean isInLayout(final View view) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) return false;
             return view.isInLayout();
@@ -158,6 +170,9 @@ public final class ViewSupport {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     static class ViewAccessorL {
+        private ViewAccessorL() {
+        }
+
         public static void setClipToOutline(View view, boolean clipToOutline) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
             view.setClipToOutline(clipToOutline);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/WebSettingsSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/WebSettingsSupport.java
@@ -25,6 +25,9 @@ import android.webkit.WebSettings;
 
 public class WebSettingsSupport {
 
+	private WebSettingsSupport() {
+	}
+
 	public static void setAllowUniversalAccessFromFileURLs(final WebSettings settings, final boolean flag) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) return;
 		WebSettingsAccessorSDK16.setAllowUniversalAccessFromFileURLs(settings, flag);

--- a/twidere/src/main/java/org/mariotaku/twidere/util/support/WindowSupport.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/support/WindowSupport.java
@@ -8,6 +8,9 @@ import android.view.Window;
  * Created by mariotaku on 14/10/23.
  */
 public class WindowSupport {
+    private WindowSupport() {
+    }
+
     public static void setStatusBarColor(Window window, int color) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
         WindowAccessorLollipop.setStatusBarColor(window, color);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.