### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/twidere/src/main/java/edu/tsinghua/hotmobi/model/SessionEvent.java
+++ b/twidere/src/main/java/edu/tsinghua/hotmobi/model/SessionEvent.java
@@ -37,6 +37,7 @@ import org.mariotaku.twidere.model.UserKey;
 import org.mariotaku.twidere.util.DataStoreUtils;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by mariotaku on 15/8/8.
@@ -79,7 +80,7 @@ public class SessionEvent extends BaseEvent implements Parcelable {
         return configuration;
     }
 
-    public HashMap<String, String> getPreferences() {
+    public Map<String, String> getPreferences() {
         return preferences;
     }
 
@@ -87,7 +88,7 @@ public class SessionEvent extends BaseEvent implements Parcelable {
         this.preferences = preferences;
     }
 
-    public HashMap<String, String> getDevicePreferences() {
+    public Map<String, String> getDevicePreferences() {
         return devicePreferences;
     }
 

--- a/twidere/src/main/java/org/mariotaku/twidere/util/AsyncTaskManager.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/AsyncTaskManager.java
@@ -27,6 +27,7 @@ import org.mariotaku.twidere.task.ManagedAsyncTask;
 
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -94,7 +95,7 @@ public final class AsyncTaskManager {
         return mHandler;
     }
 
-    public ArrayList<ManagedAsyncTask<?, ?, ?>> getTaskSpecList() {
+    public List<ManagedAsyncTask<?, ?, ?>> getTaskSpecList() {
         return new ArrayList<>(mTasks);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.