### PR TITLE
Better notification handling on Pebble Smartwatch

### DIFF
--- a/twidere/src/main/java/org/mariotaku/twidere/provider/TwidereDataProvider.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/provider/TwidereDataProvider.java
@@ -1466,7 +1466,7 @@ public final class TwidereDataProvider extends ContentProvider implements Consta
                 accountKey);
         mNotificationManager.notify("interactions", notificationId, builder.build());
 
-        Utils.sendPebbleNotification(context, pebbleNotificationStringBuilder.toString());
+        Utils.sendPebbleNotification(context, context.getResources().getString(R.string.interactions), pebbleNotificationStringBuilder.toString());
 
     }
 
@@ -1662,7 +1662,7 @@ public final class TwidereDataProvider extends ContentProvider implements Consta
                 nm.notify("messages_" + accountKey, NOTIFICATION_ID_DIRECT_MESSAGES, builder.build());
 
                 //TODO: Pebble notification - Only notify about recently added DMs, not previous ones?
-                Utils.sendPebbleNotification(context, pebbleNotificationBuilder.toString());
+                Utils.sendPebbleNotification(context, "DM", pebbleNotificationBuilder.toString());
             } catch (SecurityException e) {
                 // Silently ignore
             }

--- a/twidere/src/main/java/org/mariotaku/twidere/provider/TwidereDataProvider.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/provider/TwidereDataProvider.java
@@ -1437,11 +1437,14 @@ public final class TwidereDataProvider extends ContentProvider implements Consta
                     if (TextUtils.isEmpty(summary)) {
                         style.addLine(message.getTitle());
                         pebbleNotificationStringBuilder.append(message.getTitle());
+                        pebbleNotificationStringBuilder.append("\n");
                     } else {
                         style.addLine(SpanFormatter.format(resources.getString(R.string.title_summary_line_format),
                                 message.getTitle(), summary));
-                        pebbleNotificationStringBuilder.append(SpanFormatter.format(resources.getString(R.string.title_summary_line_format),
-                                message.getTitle(), summary));
+                        pebbleNotificationStringBuilder.append(message.getTitle());
+                        pebbleNotificationStringBuilder.append(": ");
+                        pebbleNotificationStringBuilder.append(message.getSummary());
+                        pebbleNotificationStringBuilder.append("\n");
                     }
                     messageLines++;
                 }

--- a/twidere/src/main/java/org/mariotaku/twidere/util/Utils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/Utils.java
@@ -2251,12 +2251,33 @@ public final class Utils implements Constants {
      * @param message String
      */
     public static void sendPebbleNotification(final Context context, final String message) {
+        sendPebbleNotification(context, null, message);
+    }
+
+    /**
+     * Send Notifications to Pebble smartwatches
+     *
+     * @param context Context
+     * @param title String
+     * @param message String
+     */
+    public static void sendPebbleNotification(final Context context, final String title, final String message)
+    {
+        String appName;
+
+        if ( title == null)
+        {
+            appName = context.getString(R.string.app_name);
+        }
+        else
+        {
+            appName = context.getString(R.string.app_name) + " - " + title;
+        }
+
         if (context == null || TextUtils.isEmpty(message)) return;
         final SharedPreferences prefs = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
 
         if (prefs.getBoolean(KEY_PEBBLE_NOTIFICATIONS, false)) {
-
-            final String appName = context.getString(R.string.app_name);
 
             final List<PebbleMessage> messages = new ArrayList<>();
             messages.add(new PebbleMessage(appName, message));
@@ -2268,6 +2289,7 @@ public final class Utils implements Constants {
 
             context.getApplicationContext().sendBroadcast(intent);
         }
+
     }
 
     @Nullable


### PR DESCRIPTION
Current upstream master only sends (for example) _'5 Notifications from foo and 4 others'_ string to Pebble smartwatch when Pebble smartwatch integration is enabled.
User should be able to receive content of interaction or direct message on their Pebble smartwatch.

This PR changes following things -

- In Util.java, sendPebbleNotification can now send custom titled notification in format of (appName) + variable - e.g., 'Twidere - Interaction'
- Pebble smartwatch users can now receive **actual content** of notification instead of receiving only number and sender of mention, direct messages... etc.