### PR TITLE
Get Mastodon Federated Timeline

### DIFF
--- a/twidere.component.common/src/main/java/org/mariotaku/microblog/library/mastodon/api/TimelinesResources.java
+++ b/twidere.component.common/src/main/java/org/mariotaku/microblog/library/mastodon/api/TimelinesResources.java
@@ -39,6 +39,11 @@ public interface TimelinesResources {
     LinkHeaderList<Status> getPublicTimeline(@Query Paging paging, @Query(value = "local",
             booleanEncoding = BooleanEncoding.IGNORE_IF_FALSE) boolean local)
             throws MicroBlogException;
+    
+    @GET("/v1/timelines/public")
+    LinkHeaderList<Status> getPublicTimeline(@Query Paging paging,
+            booleanEncoding = BooleanEncoding.IGNORE_IF_FALSE) boolean local)
+            throws MicroBlogException;
 
     @GET("/v1/timelines/tag/{tag}")
     LinkHeaderList<Status> getHashtagTimeline(@Path("tag") String hashtag, @Query Paging paging,


### PR DESCRIPTION
Acquires Federated Timeline resource from API. This pull does not afaik create the ability of a Mastodon user to view the Federated, it just pulls it into timeline_resources. 