### PR TITLE
Fix toggle account availbility cause toggle other account availbility

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/view/holder/AccountViewHolder.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/view/holder/AccountViewHolder.kt
@@ -67,6 +67,7 @@ class AccountViewHolder(
         adapter.requestManager.loadProfileImage(adapter.context, details, adapter.profileImageStyle,
                 profileImage.cornerRadius, profileImage.cornerRadiusRatio).into(profileImage)
         accountType.setImageResource(AccountUtils.getAccountTypeIcon(details.type))
+        toggle.setOnCheckedChangeListener(null)
         toggle.isChecked = details.activated
         toggle.setOnCheckedChangeListener(adapter.checkedChangeListener)
         toggle.tag = layoutPosition


### PR DESCRIPTION
CompoundButton.setChecked make OnCheckedChangeListener call.
So unset OnCheckedChangeListener before setChecked of other entry.