### PR TITLE
add network_security_config

### DIFF
--- a/twidere/src/main/AndroidManifest.xml
+++ b/twidere/src/main/AndroidManifest.xml
@@ -119,6 +119,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Twidere.NoActionBar"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="UnusedAttribute">
         <uses-library
             android:name="com.sec.android.app.multiwindow"

--- a/twidere/src/main/res/xml/network_security_config.xml
+++ b/twidere/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
For those guys who want to use self-sign SSL certs when setting up API proxy. \[Android 7.0+\].

Related issue: https://github.com/TwidereProject/Twidere-Android/issues/598#issuecomment-316367986

Related commit: https://github.com/owntracks/android/commit/cebcdc89436f8f90e7743a1da2d6fcca2a4e9067

Related blog: [Changes to Trusted Certificate Authorities in Android Nougat](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html)