### PR TITLE
fixed can't proxy when use username and password

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/util/HttpClientFactory.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/util/HttpClientFactory.kt
@@ -228,7 +228,16 @@ object HttpClientFactory {
                     }
                     val address = InetSocketAddress.createUnresolved(proxyHost, proxyPort)
                     builder.proxy(Proxy(Proxy.Type.HTTP, address))
-
+                    builder.proxyAuthenticator { _, response ->
+                        val b = response.request().newBuilder()
+                        if (response.code() == 407) {
+                        if (username != null && password != null) {
+                            val credential = Credentials.basic(username, password)
+                            b.header("Proxy-Authorization", credential)
+                        }
+                        }
+                        b.build()
+                    }
                     builder.authenticator { _, response ->
                         val b = response.request().newBuilder()
                         if (response.code() == 407) {


### PR DESCRIPTION
#1172 fixed it, the source code not set proxy properties of builder.proxyAuthenticator()