### PR TITLE
Temporary fix for #1181

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
         jcenter()
         maven { url 'https://plugins.gradle.org/m2/' }
         maven { url 'https://maven.google.com' }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -35,7 +36,7 @@ allprojects {
 subprojects {
     buildscript {
         ext {
-            kotlinVersion = '1.1.51'
+            kotlinVersion = '1.3.0'
             pluginVersions = [
                     AndroidSvgDrawable: '3.0.0',
                     PlayServices      : '3.1.1',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/twidere/src/main/kotlin/org/mariotaku/twidere/activity/ComposeActivity.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/activity/ComposeActivity.kt
@@ -1372,7 +1372,7 @@ class ComposeActivity : BaseActivity(), OnMenuItemClickListener, OnClickListener
         menu.setItemAvailability(R.id.attachment_visibility_submenu, hasAttachmentStatusVisibility)
         menu.setItemAvailability(R.id.location_submenu, hasLocationOption)
 
-        ThemeUtils.wrapMenuIcon(menuBar, excludeGroups = MENU_GROUP_IMAGE_EXTENSION)
+        ThemeUtils.wrapMenuIcon(menuBar, excludeGroups = *intArrayOf(MENU_GROUP_IMAGE_EXTENSION))
         ThemeUtils.resetCheatSheet(menuBar)
     }
 
@@ -1510,7 +1510,7 @@ class ComposeActivity : BaseActivity(), OnMenuItemClickListener, OnClickListener
             return
         }
 
-        LengthyOperationsService.updateStatusesAsync(this, update.draft_action, statuses = update,
+        LengthyOperationsService.updateStatusesAsync(this, update.draft_action, statuses = *arrayOf(update),
                 scheduleInfo = scheduleInfo)
         finishComposing()
     }

--- a/twidere/src/main/kotlin/org/mariotaku/twidere/loader/statuses/ConversationLoader.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/loader/statuses/ConversationLoader.kt
@@ -89,7 +89,9 @@ class ConversationLoader(
         canLoadAllReplies = false
         when (account.type) {
             AccountType.TWITTER -> {
-                val isOfficial = account.isOfficial(context)
+                // TODO: temporary workaround for issue #1181
+                // val isOfficial = account.isOfficial(context)
+                val isOfficial = false
                 canLoadAllReplies = isOfficial
                 if (isOfficial) {
                     return microBlog.showConversation(status.id, paging).mapMicroBlogToPaginated {

--- a/twidere/src/main/kotlin/org/mariotaku/twidere/view/holder/status/DetailStatusViewHolder.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/view/holder/status/DetailStatusViewHolder.kt
@@ -468,7 +468,7 @@ class DetailStatusViewHolder(
             retweetProvider.init(itemView.menuBar, retweetItem)
         }
 
-        ThemeUtils.wrapMenuIcon(itemView.menuBar, excludeGroups = Constants.MENU_GROUP_STATUS_SHARE)
+        ThemeUtils.wrapMenuIcon(itemView.menuBar, excludeGroups = *intArrayOf(Constants.MENU_GROUP_STATUS_SHARE))
         itemView.mediaPreviewLoad.setOnClickListener(this)
         itemView.profileContainer.setOnClickListener(this)
         retweetedByView.setOnClickListener(this)


### PR DESCRIPTION
This pull request makes Twidere fall back to non-official keys approach to reading conversation threads, since the 'official' endpoint for this was apparently removed in API v1.1

I was originally planning to base these changes on `develop`, but unfortunately it's half broken - most screens in settings just make the app crash. So it's based on the last stable version instead (`master`).

I also had to upgrade Kotlin version since the latest Android Studio refused to build `master`. I did that in a separate commit for clarity.