### PR TITLE
Remove your own mention in conversation

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/activity/ComposeActivity.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/activity/ComposeActivity.kt
@@ -1000,6 +1000,7 @@ class ComposeActivity : BaseActivity(), OnMenuItemClickListener, OnClickListener
             }
             AccountType.MASTODON -> {
                 addMastodonMentions(status.text_unescaped, status.spans, mentions)
+                mentions.remove("${accountUser.screen_name}@${accountUser.key.host}")
             }
             else -> if (status.mentions.isNotNullOrEmpty()) {
                 status.mentions.filterNot {


### PR DESCRIPTION
When you reply in a conversation on Mastodon, the reply option add yourself at the end of the message. It's annoying

Example in this screenshot : 
<img width="514" alt="Capture d’écran 2020-04-20 à 11 42 47" src="https://user-images.githubusercontent.com/961976/79737795-24dc2c80-82fc-11ea-9fe9-14b7e71ee676.png">

For instance, I'm xefir@shelter.moe
