### PR TITLE
Show media around cutouts in media viewer whilst fullscreen

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/fragment/media/ExoPlayerPageFragment.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/fragment/media/ExoPlayerPageFragment.kt
@@ -274,11 +274,11 @@ class ExoPlayerPageFragment : MediaViewerFragment(), IBaseFragment<ExoPlayerPage
     }
 
     override fun onApplySystemWindowInsets(insets: Rect) {
-        val lp = videoControl.layoutParams
-        if (lp is ViewGroup.MarginLayoutParams) {
-            lp.bottomMargin = insets.bottom
-            lp.leftMargin = insets.left
-            lp.rightMargin = insets.right
+        // HACK: Apply maximum reported system inset to avoid drawing under systum UI
+        (videoControl.layoutParams as? ViewGroup.MarginLayoutParams)?.apply {
+          bottomMargin = maxOf(insets.bottom, bottomMargin)
+          leftMargin = maxOf(insets.left, leftMargin)
+          rightMargin = maxOf(insets.right, rightMargin)
         }
     }
 

--- a/twidere/src/main/res/values/themes.xml
+++ b/twidere/src/main/res/values/themes.xml
@@ -41,6 +41,7 @@
         <!-- Window attributes -->
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
 
         <item name="windowActionBarOverlay">true</item>
         <item name="actionBarStyle">@style/Widget.Twidere.Viewer.ActionBar</item>


### PR DESCRIPTION
This is a retry at #1221 which fixes #1261.
It's a little hacky. I think one of the parent views is consuming the system window insets.

However if you rotate the screen in and out of landscape the video controller is shortened as pictured:

![viewer_cutout_redux](https://user-images.githubusercontent.com/334272/80764416-96a44980-8b38-11ea-92d8-c470c1d466b1.png)
