### PR TITLE
Contribution guide: use the maintenance branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How To Contribute #
 
 First of all, I'd like to express my appreciation to you for contributing to this project.
- 
+
 ## Working Branch ##
 
-You should make changes on `develop` branch, changes will be merged into `master` branch after a stable version released.
+You should make changes on the `maintenance` branch, changes will be merged into `master` branch after a stable version released.


### PR DESCRIPTION
Replaces the `develop` branch with the `maintenance` one.