### PR TITLE
Mastodon: get the list of real boosters of a toot

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/loader/users/StatusRetweetersLoader.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/loader/users/StatusRetweetersLoader.kt
@@ -48,7 +48,7 @@ class StatusRetweetersLoader(
         when (details.type) {
             AccountType.MASTODON -> {
                 val mastodon = details.newMicroBlogInstance(context, Mastodon::class.java)
-                val response = mastodon.getStatusFavouritedBy(statusId)
+                val response = mastodon.getStatusRebloggedBy(statusId)
                 return PaginatedArrayList<ParcelableUser>(response.size).apply {
                     response.mapTo(this) { account ->
                         account.toParcelable(details)


### PR DESCRIPTION
Gets the list of users who boosted (reblogged) a toot instead of those who favourited this toot.

Fix #1094