### PR TITLE
Increase the max user profile name length to 50.

### DIFF
--- a/twidere/src/main/res/layout/fragment_user_profile_editor.xml
+++ b/twidere/src/main/res/layout/fragment_user_profile_editor.xml
@@ -160,7 +160,7 @@
                     app:met_baseColor="?android:textColorPrimary"
                     app:met_floatingLabel="normal"
                     app:met_floatingLabelText="@string/user_profile_name"
-                    app:met_maxCharacters="20"
+                    app:met_maxCharacters="50"
                     app:met_primaryColor="?colorAccent"
                     tools:text="TwidereProject"/>
 


### PR DESCRIPTION
This was changed way back in 2017. The edit screen still shows `x/20` while editing, though.
https://www.theverge.com/2017/11/10/16632994/twitter-50-character-display-names