### PR TITLE
feat: KEY_CONNECTION_TIMEOUT set read write timeouts too

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/util/HttpClientFactory.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/util/HttpClientFactory.kt
@@ -190,8 +190,8 @@ object HttpClientFactory {
 
     class HttpClientConfiguration(val prefs: SharedPreferences) {
 
-        var readTimeoutSecs: Long = -1
-        var writeTimeoutSecs: Long = -1
+        var readTimeoutSecs: Long = prefs.getInt(KEY_CONNECTION_TIMEOUT, 10).toLong()
+        var writeTimeoutSecs: Long = prefs.getInt(KEY_CONNECTION_TIMEOUT, 10).toLong()
         var connectionTimeoutSecs: Long = prefs.getInt(KEY_CONNECTION_TIMEOUT, 10).toLong()
         var cacheSize: Int = prefs[cacheSizeLimitKey]
 


### PR DESCRIPTION
Fix #997 

* `KEY_CONNECTION_TIMEOUT` is now use to set `writeTimeout` and `readTimeout`
* Can be change through the hidden menu with dialing `*#*#8943373#*#*`

We might want to add `KEY_READ_TIMEOUT` and `KEY_WRITE_TIMEOUT` ? I'm not sure it's necessary.

