### PR TITLE
Fix import/export for Android R+

### DIFF
--- a/twidere/src/main/java/org/mariotaku/twidere/util/DataImportExportUtils.java
+++ b/twidere/src/main/java/org/mariotaku/twidere/util/DataImportExportUtils.java
@@ -84,8 +84,8 @@ public class DataImportExportUtils implements Constants {
             | FLAG_HOST_MAPPING | FLAG_KEYBOARD_SHORTCUTS | FLAG_FILTERS | FLAG_TABS;
 
     @WorkerThread
-    public static void exportData(final Context context, @NonNull final DocumentFile dst, final int flags) throws IOException {
-        try (OutputStream fos = context.getContentResolver().openOutputStream(dst.getUri());
+    public static void exportData(final Context context, @NonNull final Uri dst, final int flags) throws IOException {
+        try (OutputStream fos = context.getContentResolver().openOutputStream(dst);
              ZipOutputStream zos = new ZipOutputStream(fos)) {
             if (hasFlag(flags, FLAG_PREFERENCES)) {
                 exportSharedPreferencesData(zos, context, SHARED_PREFERENCES_NAME, ENTRY_PREFERENCES,
@@ -199,9 +199,9 @@ public class DataImportExportUtils implements Constants {
         }
     }
 
-    public static void importData(final Context context, final DocumentFile src, final int flags) throws IOException {
+    public static void importData(final Context context, final Uri src, final int flags) throws IOException {
         if (src == null) throw new FileNotFoundException();
-        try (InputStream inputStream = context.getContentResolver().openInputStream(src.getUri());
+        try (InputStream inputStream = context.getContentResolver().openInputStream(src);
              ZipInputStream zipInputStream = new ZipInputStream(inputStream)
         ) {
             ZipEntry entry;


### PR DESCRIPTION
Don't use DocumentFile and pick file via ACTION_OPEN_DOCUMENT so a
right Uri with the right permissions is passed to the import class.

--

Import/Export was totally broken on Android 11. It was the case partially due to lack of proper SAF permissions given by ACTION_OPEN_DOCUMENT and partially due to DocumentFile breaking URI's.

I tried to replicate old behavior for Pie and older so it would not affect anyone. I tested it on R and KK (AVD), so it should as fine as the previous version.