### PR TITLE
Switch auto theme mode to Android built-in mechanism

### DIFF
--- a/twidere/src/main/kotlin/androidx/appcompat/app/TwilightManagerAccessor.kt
+++ b/twidere/src/main/kotlin/androidx/appcompat/app/TwilightManagerAccessor.kt
@@ -8,7 +8,13 @@ import android.content.Context
 
 object TwilightManagerAccessor {
     fun isNight(context: Context): Boolean {
-        return TwilightManager.getInstance(context).isNight
+        //From https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#kotlin
+        val currentNightMode: Int = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        when (currentNightMode) {
+            Configuration.UI_MODE_NIGHT_NO -> { return false }
+            Configuration.UI_MODE_NIGHT_YES -> { return true }
+        }
+        return false;
     }
 
     fun getNightState(context: Context): Int {

--- a/twidere/src/main/kotlin/androidx/appcompat/app/TwilightManagerAccessor.kt
+++ b/twidere/src/main/kotlin/androidx/appcompat/app/TwilightManagerAccessor.kt
@@ -5,6 +5,7 @@ import android.content.res.Configuration
 
 /**
  * Created by mariotaku on 2017/1/7.
+ * Edited by 0x416c6578 on 2021/8/3
  */
 
 object TwilightManagerAccessor {

--- a/twidere/src/main/kotlin/androidx/appcompat/app/TwilightManagerAccessor.kt
+++ b/twidere/src/main/kotlin/androidx/appcompat/app/TwilightManagerAccessor.kt
@@ -1,6 +1,7 @@
 package androidx.appcompat.app
 
 import android.content.Context
+import android.content.res.Configuration
 
 /**
  * Created by mariotaku on 2017/1/7.


### PR DESCRIPTION
This addresses [this issue](https://github.com/TwidereProject/Twidere-Android/issues/1428) by using the recommended mechanism for theme changes. It might be possible to remove references to TwilightManager, however I'm not confident enough to do that at this point.