### PR TITLE
Use a more modern Twitter Android version that works

### DIFF
--- a/twidere/src/main/kotlin/org/mariotaku/twidere/util/api/TwitterAndroidExtraHeaders.kt
+++ b/twidere/src/main/kotlin/org/mariotaku/twidere/util/api/TwitterAndroidExtraHeaders.kt
@@ -32,9 +32,9 @@ import java.util.*
 object TwitterAndroidExtraHeaders : ExtraHeaders {
 
     const val clientName = "TwitterAndroid"
-    const val versionName = "6.41.0"
+    const val versionName = "8.50.0-release.02"
     const val apiVersion = "5"
-    const val internalVersionName = "7160062-r-930"
+    const val internalVersionName = "18500002-r-2"
 
     override fun get(headers: MultiValueMap<String>): List<Pair<String, String>> {
         val result = ArrayList<Pair<String, String>>()


### PR DESCRIPTION
This change allows me to use Twidere again after the 3rd-party API ban. You just need to use the official Android consumer key and it works. XAuth works too.

I know that this project is not actively maintained, but please consider releasing this minor update 🙏 

Potentially fixes #1478 (I haven't encountered it so couldn't test)